### PR TITLE
Update the symfony/validation version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "graze/hamcrest-test-listener": "^1.0.1",
 
         "respect/validation": "^1.0",
-        "symfony/validator": "^2.6",
+        "symfony/validator": "^2.6.2",
         "zendframework/zend-validator": "^2.3"
     }
 }


### PR DESCRIPTION
symfony/validator v2.6.0 requires symfony/translation v2.0.4, which doesn't use any composer autoloading.

This is resolved in symfony/validator v2.6.2 and above.
